### PR TITLE
Order by Protect/Pocket Pick by Opalkmm

### DIFF
--- a/src/drawing-list.tsx
+++ b/src/drawing-list.tsx
@@ -9,8 +9,16 @@ import { Callout, NonIdealState } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import logo from "./assets/ddr-tools-256.png";
 
-const renderDrawing = (drawing: Drawing) => (
-  <DrawnSet key={drawing.id} drawing={drawing} />
+const giveDrawnChartsIds = (drawing:Drawing) => {
+  let idCount = 0;
+  drawing.charts.map((chart) => {
+    chart.id = idCount++;
+    return chart;
+  })
+  return drawing;
+}
+const renderDrawing = (drawing: Drawing) => (  
+  <DrawnSet key={drawing.id} drawing={giveDrawnChartsIds(drawing)} />
 );
 
 const ScrollableDrawings = memo((props: { drawings: Drawing[] }) => {
@@ -20,6 +28,10 @@ const ScrollableDrawings = memo((props: { drawings: Drawing[] }) => {
 export function DrawingList() {
   const { drawings } = useContext(DrawStateContext);
   const configState = useContext(ConfigStateContext);
+  const flagsArr = Array.from(configState.flags);
+  const orderByPocketPick = flagsArr.includes("orderByPocketPick");
+  drawings.map(drawing => drawing.orderByPocketPick = orderByPocketPick);
+
   if (configState.showPool) {
     return <EligibleChartsList />;
   }

--- a/src/drawn-set.tsx
+++ b/src/drawn-set.tsx
@@ -37,12 +37,12 @@ export class DrawnSet extends Component<Props> {
   }
 
   renderChart = (chart: DrawnChart, index: number) => {
-    const veto = this.props.drawing.bans.find((b) => b.chartIndex === index);
+    const veto = this.props.drawing.bans.find((b) => b.chartId === chart.id);
     const protect = this.props.drawing.protects.find(
-      (b) => b.chartIndex === index
+      (b) => b.chartId === chart.id
     );
     const pocketPick = this.props.drawing.pocketPicks.find(
-      (b) => b.chartIndex === index
+      (b) => b.chartId === chart.id
     );
     return (
       <SongCard
@@ -51,19 +51,19 @@ export class DrawnSet extends Component<Props> {
           onVeto: this.handleBanProtectReplace.bind(
             this,
             this.props.drawing.bans,
-            index
+            chart.id as number,
           ),
           onProtect: this.handleBanProtectReplace.bind(
             this,
             this.props.drawing.protects,
-            index
+            chart.id as number
           ),
           onReplace: this.handleBanProtectReplace.bind(
             this,
             this.props.drawing.pocketPicks,
-            index
+            chart.id as number
           ),
-          onReset: this.handleReset.bind(this, index),
+          onReset: this.handleReset.bind(this, chart.id as number),
         }}
         vetoedBy={veto && veto.player}
         protectedBy={protect && protect.player}
@@ -73,30 +73,37 @@ export class DrawnSet extends Component<Props> {
       />
     );
   };
-
   handleBanProtectReplace(
     arr: Array<PlayerActionOnChart> | Array<PocketPick>,
-    chartIndex: number,
+    chartId: number,
     player: 1 | 2,
-    chart?: DrawnChart
+    chart: DrawnChart,
   ) {
-    const existingBanIndex = arr.findIndex((b) => b.chartIndex === chartIndex);
+    const existingBanIndex = arr.findIndex((b) => b.chartId === chart?.id);
     if (existingBanIndex >= 0) {
       arr.splice(existingBanIndex, 1);
     } else {
-      arr.push({ chartIndex, player, pick: chart! });
+      arr.push({ player, pick: chart!, chartId });
+    }
+
+    if(arr !== this.props.drawing.bans && this.props.drawing.orderByPocketPick){
+    const shiftedChart = this.props.drawing.charts.find(chart => chart.id === chartId) as DrawnChart;
+    const indexToCut = this.props.drawing.charts.indexOf(shiftedChart);
+    
+    this.props.drawing.charts.splice(indexToCut, 1);
+    this.props.drawing.charts.unshift(shiftedChart);
     }
     this.forceUpdate();
   }
-
-  handleReset(chartIndex: number) {
+  
+  handleReset(chartId: number) {
     const drawing = this.props.drawing;
-    drawing.bans = drawing.bans.filter((p) => p.chartIndex !== chartIndex);
+    drawing.bans = drawing.bans.filter((p) => p.chartId !== chartId);
     drawing.protects = drawing.protects.filter(
-      (p) => p.chartIndex !== chartIndex
+      (p) => p.chartId !== chartId
     );
     drawing.pocketPicks = drawing.pocketPicks.filter(
-      (p) => p.chartIndex !== chartIndex
+      (p) => p.chartId !== chartId
     );
     this.forceUpdate();
   }

--- a/src/models/Drawing.ts
+++ b/src/models/Drawing.ts
@@ -12,11 +12,12 @@ export interface DrawnChart {
   hasShock: boolean;
   flags: string[];
   song: Song;
+  id?: number;
 }
 
 export interface PlayerActionOnChart {
   player: 1 | 2;
-  chartIndex: number;
+  chartId: number;
 }
 
 export interface PocketPick extends PlayerActionOnChart {
@@ -29,4 +30,5 @@ export interface Drawing {
   bans: Array<PlayerActionOnChart>;
   protects: Array<PlayerActionOnChart>;
   pocketPicks: Array<PocketPick>;
+  orderByPocketPick?: boolean;
 }

--- a/src/song-card/icon-menu.tsx
+++ b/src/song-card/icon-menu.tsx
@@ -1,13 +1,13 @@
 import { useIntl } from "../hooks/useIntl";
 import { IconNames, IconName } from "@blueprintjs/icons";
 import { Menu, MenuItem } from "@blueprintjs/core";
+import { DrawnChart } from "../models/Drawing";
 
 interface Props {
-  onStartPocketPick: (p: 1 | 2) => void;
-  onVeto: (p: 1 | 2) => void;
-  onProtect: (p: 1 | 2) => void;
+  onStartPocketPick: (p: 1 | 2, chart: DrawnChart) => void;
+  onVeto: (p: 1 | 2, chart: DrawnChart, chartId: number) => void;
+  onProtect: (p: 1 | 2, chart: DrawnChart, chartId: number) => void;
 }
-
 export function IconMenu(props: Props) {
   const { onStartPocketPick, onVeto, onProtect } = props;
 
@@ -37,14 +37,15 @@ export function IconMenu(props: Props) {
 interface IconRowProps {
   icon: IconName;
   text: string;
-  onClick: (p: 1 | 2) => void;
+  onClick: (p: 1 | 2, chart: DrawnChart, chartId: number) => void;
+  chart?: DrawnChart;
 }
 
-function MenuPair({ icon, text, onClick }: IconRowProps) {
+function MenuPair({ icon, text, onClick, chart }: IconRowProps) {
   return (
     <MenuItem icon={icon} text={text}>
-      <MenuItem text="P1" onClick={() => onClick(1)} icon={IconNames.PERSON} />
-      <MenuItem text="P2" onClick={() => onClick(2)} icon={IconNames.PERSON} />
+      <MenuItem text="P1" onClick={() => onClick(1, chart as DrawnChart, chart?.id as number)} icon={IconNames.PERSON} />
+      <MenuItem text="P2" onClick={() => onClick(2, chart as DrawnChart, chart?.id as number)} icon={IconNames.PERSON} />
     </MenuItem>
   );
 }

--- a/src/song-card/song-card.tsx
+++ b/src/song-card/song-card.tsx
@@ -16,9 +16,9 @@ const isJapanese = detectedLanguage === "ja";
 type Player = 1 | 2;
 
 interface IconCallbacks {
-  onVeto: (p: Player) => void;
-  onProtect: (p: Player) => void;
-  onReplace: (p: Player, chart: DrawnChart) => void;
+  onVeto: (p: Player, chart: DrawnChart, chartId: number) => void;
+  onProtect: (p: Player, chart: DrawnChart, chartId: number) => void;
+  onReplace: (p: Player, chart: DrawnChart, chartId: number) => void;
   onReset: () => void;
 }
 
@@ -56,7 +56,7 @@ export function SongCard(props: Props) {
     difficultyClass,
     level,
     hasShock,
-    jacket,
+    jacket
   } = replacedWith || chart;
   const diffAccentColor = useDifficultyColor(difficultyClass);
 
@@ -101,7 +101,7 @@ export function SongCard(props: Props) {
         onSongSelect={(song, chart) => {
           iconCallbacks &&
             chart &&
-            iconCallbacks.onReplace(pocketPickForPlayer as 1 | 2, chart);
+            iconCallbacks.onReplace(pocketPickForPlayer as 1 | 2, chart, chart.id as number);
           setPocketPickForPlayer(0);
         }}
         onCancel={() => setPocketPickForPlayer(0)}

--- a/src/songs/a20plus.json
+++ b/src/songs/a20plus.json
@@ -15,7 +15,8 @@
       "extraExclusive",
       "goldExclusive",
       "usLocked",
-      "tempUnlock"
+      "tempUnlock",
+      "orderByPocketPick"
     ],
     "lvlMax": 19,
     "lastUpdated": 1641352956000
@@ -23,7 +24,7 @@
   "defaults": {
     "style": "single",
     "difficulties": ["expert", "challenge"],
-    "flags": ["shock"],
+    "flags": ["shock", "orderByPocketPick"],
     "lowerLvlBound": 13,
     "upperLvlBound": 16
   },
@@ -44,6 +45,7 @@
       "usLocked": "Japan-only songs",
       "tempUnlock": "Formerly unlockable (SDVX, DRS, etc)",
       "shock": "Shock arrow charts",
+      "orderByPocketPick": "Enable Order by Protect/Pocket Pick",
       "$abbr": {
         "beginner": "Beg",
         "basic": "Bas",
@@ -65,6 +67,7 @@
       "goldExclusive": "A20筐体限定曲を含める",
       "goldenLeague": "Golden League",
       "extraExclusive": "EXTRA EXCLUSIVE曲を含める",
+      "orderByPocketPick": "Enable Order by Protect/Pocket Pick",
       "usLocked": "日本限定曲を含める",
       "tempUnlock": "現在解禁できない曲を含める",
       "shock": "Shock arrow charts",

--- a/src/songs/drs.json
+++ b/src/songs/drs.json
@@ -5,14 +5,14 @@
       { "key": "easy", "color": "#72cc6e" },
       { "key": "normal", "color": "#e0de5c" }
     ],
-    "flags": ["unlock", "extraExclusive", "tempUnlock"],
+    "flags": ["unlock", "extraExclusive", "tempUnlock", "orderByPocketPick"],
     "lvlMax": 10,
     "lastUpdated": 1595833183000
   },
   "defaults": {
     "style": "single",
     "difficulties": ["easy", "normal"],
-    "flags": ["unlock"],
+    "flags": ["unlock", "orderByPocketPick"],
     "lowerLvlBound": 7,
     "upperLvlBound": 10
   },
@@ -23,6 +23,7 @@
       "easy": "Easy",
       "normal": "Normal",
       "unlock": "Stars Unlock",
+      "orderByPocketPick": "Enable Order by Protect/Pocket Pick",
       "extraExclusive": "Extra Stage/Standard Mode",
       "tempUnlock": "Event Unlock (Spark Festival, GYM, Dance Camp, KAC, etc)",
       "$abbr": { "easy": "E", "normal": "N" }
@@ -33,6 +34,7 @@
       "easy": "Easy",
       "normal": "Normal",
       "unlock": "スターロック解除",
+      "orderByPocketPick": "Enable Order by Protect/Pocket Pick",
       "extraExclusive": "追加ステージ/標準モード",
       "tempUnlock": "イベントのロック解除（スパークフェスティバル、ジム、ダンスキャンプ、KACなど）",
       "$abbr": { "easy": "E", "normal": "N" }

--- a/src/songs/extreme.json
+++ b/src/songs/extreme.json
@@ -7,14 +7,14 @@
       { "key": "expert", "color": "#72cc6e" },
       { "key": "challenge", "color": "#cc71e8" }
     ],
-    "flags": [],
+    "flags": ["orderByPocketPick"],
     "lvlMax": 10,
     "lastUpdated": 1595833183000
   },
   "defaults": {
     "style": "single",
     "difficulties": ["expert", "challenge"],
-    "flags": [],
+    "flags": ["orderByPocketPick"],
     "lowerLvlBound": 6,
     "upperLvlBound": 10
   },
@@ -27,6 +27,7 @@
       "difficult": "Standard",
       "expert": "Heavy",
       "challenge": "Challenge",
+      "orderByPocketPick": "Enable Order by Protect/Pocket Pick",
       "$abbr": {
         "basic": "Lgt",
         "difficult": "Std",
@@ -42,6 +43,7 @@
       "difficult": "Standard",
       "expert": "Heavy",
       "challenge": "Challenge",
+      "orderByPocketPick": "Enable Order by Protect/Pocket Pick",
       "$abbr": {
         "basic": "楽",
         "difficult": "踊",

--- a/src/songs/sdvx.json
+++ b/src/songs/sdvx.json
@@ -11,7 +11,7 @@
       { "key": "heavenly", "color": "#00ffff" },
       { "key": "vivid", "color": "#f52a6e" }
     ],
-    "flags": [],
+    "flags": ["orderByPocketPick"],
     "lvlMax": 20,
     "lastUpdated": 1595832765000
   },
@@ -25,7 +25,7 @@
       "heavenly",
       "vivid"
     ],
-    "flags": [],
+    "flags": ["orderByPocketPick"],
     "lowerLvlBound": 16,
     "upperLvlBound": 19
   },
@@ -41,6 +41,7 @@
       "gravity": "Gravity",
       "heavenly": "Heavenly",
       "vivid": "Vivid",
+      "orderByPocketPick": "Enable Order by Protect/Pocket Pick",
       "$abbr": {
         "novice": "NOV",
         "advanced": "ADV",

--- a/src/songs/smx.json
+++ b/src/songs/smx.json
@@ -10,7 +10,7 @@
       { "key": "full", "color": "#00d0b8" },
       { "key": "team", "color": "#c216ce" }
     ],
-    "flags": ["andorfineMedia", "bassmonkeys", "cappRecords", "dimaMusic"],
+    "flags": ["andorfineMedia", "bassmonkeys", "cappRecords", "dimaMusic", "orderByPocketPick"],
     "lvlMax": 28,
     "lastUpdated": 1651354852324
   },
@@ -36,6 +36,7 @@
       "bassmonkeys": "The Bassmonkeys Pack",
       "cappRecords": "CAPP Records",
       "dimaMusic": "Dima Music",
+      "orderByPocketPick": "Enable Order by Protect/Pocket Pick",
       "$abbr": {
         "basic": "Basic",
         "easy": "Easy",


### PR DESCRIPTION
Add checkmark in settings to enable ordering song draw by protect/pocket pick upon user interaction.  When enabled, Protected and Pocket Picked songs will move to the front of the drawn set. 